### PR TITLE
Fix CV Docx path in sitemap script

### DIFF
--- a/scripts/generate-sitemap.cjs
+++ b/scripts/generate-sitemap.cjs
@@ -11,7 +11,7 @@ const urls = [
   },
   {
     url: '/cv',
-    files: ['src/pages/CV.tsx', 'src/components/cv/CVDocument.tsx', 'src/components/cv/CVDocumentDocx.tsx'],
+    files: ['src/pages/CV.tsx', 'src/components/cv/CVDocument.tsx', 'src/components/cv/CVDocumentDocx.js'],
     priority: 0.8
   },
   {


### PR DESCRIPTION
## Summary
- correct reference to `CVDocumentDocx.js` in sitemap generator

## Testing
- `node scripts/generate-sitemap.cjs`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6bd54f3c8325b80092d0198bfbb6