### PR TITLE
Update default port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is a personal portfolio website built with React, TypeScript, Vite, and Tai
     ```bash
     npm run dev
     ```
-    This will start the Vite development server, usually on `http://localhost:5173`. The application will automatically reload if you change any of the source files.
+    This will start the Vite development server, usually on `http://localhost:8080`. The application will automatically reload if you change any of the source files.
 
 ## Building the Project
 


### PR DESCRIPTION
## Summary
- update the README to use port `8080` instead of `5173`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f6bd7476083258f6b5092a5f34537