### PR TITLE
Fix form context defaults

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,31 +3,31 @@
 
   <url>
     <loc>https://uweschwarz.eu/</loc>
-    <lastmod>2025-05-28</lastmod>
+    <lastmod>2025-06-03</lastmod>
     <priority>1</priority>
   </url>
 
   <url>
     <loc>https://uweschwarz.eu/cv</loc>
-    <lastmod>2025-05-28</lastmod>
+    <lastmod>2025-06-03</lastmod>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://uweschwarz.eu/imprint</loc>
-    <lastmod>2025-05-28</lastmod>
+    <lastmod>2025-06-03</lastmod>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://uweschwarz.eu/privacy</loc>
-    <lastmod>2025-05-28</lastmod>
+    <lastmod>2025-06-03</lastmod>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://uweschwarz.eu/sitemap</loc>
-    <lastmod>2025-05-28</lastmod>
+    <lastmod>2025-06-03</lastmod>
     <priority>0.3</priority>
   </url>
 

--- a/src/components/ui/form-context.ts
+++ b/src/components/ui/form-context.ts
@@ -13,8 +13,8 @@ export type FormFieldContextValue<
   name: TName
 }
 
-export const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
+export const FormFieldContext = React.createContext<FormFieldContextValue | null>(
+  null
 )
 
 // Original FormItemContextValue and FormItemContext
@@ -22,25 +22,26 @@ export type FormItemContextValue = {
   id: string
 }
 
-export const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
+export const FormItemContext = React.createContext<FormItemContextValue | null>(
+  null
 )
 
 // Original useFormField hook
 export const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
-
-  const fieldState = getFieldState(fieldContext.name, formState)
 
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
   }
-  
+
   if (!itemContext) {
     throw new Error("useFormField should be used within <FormItem>")
   }
+
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
 
 
   const { id } = itemContext


### PR DESCRIPTION
## Summary
- ensure form context hooks throw if used outside their providers

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683f69c1bebc8325961833e47c65b7fe