### PR TITLE
Add contribution docs and agent guidelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS Instructions
+
+This repository contains a personal portfolio built with React, TypeScript, Vite and Tailwind CSS.
+
+## Project layout
+- `src/` – application source code (pages, components, hooks).
+- `public/` – static assets such as the generated `sitemap.xml`.
+- `scripts/` – utility scripts executed by the build or git hooks.
+
+## Useful commands
+- `npm run dev` – start a development server on port 8080.
+- `npm run build` – create a production build.
+- `npm run lint` – run ESLint over the codebase.
+- `npm test` – execute unit tests via Vitest.
+
+## Git hooks
+A pre-commit hook is configured with Husky. It runs `node scripts/generate-sitemap.cjs` and stages the resulting `public/sitemap.xml` file. Ensure the sitemap is updated and committed when making changes.
+
+## Agent workflow
+When modifying files in this repository:
+1. Run `npm run lint` and `npm test` before committing to confirm everything passes.
+2. Include a clear commit message summarising the change.
+3. Reference any modified files in PR summaries when applicable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+This repository hosts a React + TypeScript portfolio site. To contribute changes:
+
+1. Install dependencies with `npm install`.
+2. Run `npm run lint` and `npm test` to verify code quality and tests.
+3. Make your changes in a feature branch.
+4. Commit with a descriptive message and open a pull request.
+
+All pull requests automatically generate a sitemap through the pre-commit hook.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -15,19 +15,19 @@
 
   <url>
     <loc>https://uweschwarz.eu/imprint</loc>
-    <lastmod>2025-06-04</lastmod>
+    <lastmod>2025-06-05</lastmod>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://uweschwarz.eu/privacy</loc>
-    <lastmod>2025-06-04</lastmod>
+    <lastmod>2025-06-05</lastmod>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>https://uweschwarz.eu/sitemap</loc>
-    <lastmod>2025-06-04</lastmod>
+    <lastmod>2025-06-05</lastmod>
     <priority>0.3</priority>
   </url>
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -23,6 +23,6 @@ if (!('ResizeObserver' in window)) {
     unobserve() {}
     disconnect() {}
   }
-  // @ts-ignore
+  // @ts-expect-error ResizeObserver not implemented in jsdom
   window.ResizeObserver = ResizeObserver
 }


### PR DESCRIPTION
## Summary
- document repo usage in AGENTS.md
- add CONTRIBUTING doc for devs
- include standard editorconfig
- fix lint failure in setupTests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68420d56cbb88320809b72f5a2d1c919