### PR TITLE
chore(deps): upgrade react-pdf renderer and workflow action

### DIFF
--- a/.github/workflows/update-umami-tracker.yml
+++ b/.github/workflows/update-umami-tracker.yml
@@ -33,7 +33,7 @@ jobs:
         run: bun run update:umami
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           branch: codex/update-umami-tracker
           commit-message: "chore: update vendored Umami tracker"

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.6",
-        "@react-pdf/renderer": "^4.4.0",
+        "@react-pdf/renderer": "^4.4.1",
         "@tanstack/react-query": "^5.97.0",
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
@@ -429,7 +429,7 @@
 
     "@react-pdf/image": ["@react-pdf/image@3.0.4", "", { "dependencies": { "@react-pdf/png-js": "^3.0.0", "jay-peg": "^1.1.1" } }, "sha512-z0ogVQE0bKqgXQ5smgzIU857rLV7bMgVdrYsu3UfXDDLSzI7QPvzf6MFTFllX6Dx2rcsF13E01dqKPtJEM799g=="],
 
-    "@react-pdf/layout": ["@react-pdf/layout@4.5.0", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "@react-pdf/image": "^3.0.4", "@react-pdf/primitives": "^4.2.0", "@react-pdf/stylesheet": "^6.1.4", "@react-pdf/textkit": "^6.1.1", "@react-pdf/types": "^2.10.0", "emoji-regex-xs": "^1.0.0", "queue": "^6.0.1", "yoga-layout": "^3.2.1" } }, "sha512-XlGLzcZFdEYQHK6b9z9uPOVywbjv6pQ92D4RvqRmYNjpf7lQLnhdHr63tbiF7fB5k8Lg9/lGBXkHbzkeQW5geQ=="],
+    "@react-pdf/layout": ["@react-pdf/layout@4.5.1", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "@react-pdf/image": "^3.0.4", "@react-pdf/primitives": "^4.2.0", "@react-pdf/stylesheet": "^6.1.4", "@react-pdf/textkit": "^6.2.0", "@react-pdf/types": "^2.10.0", "emoji-regex-xs": "^1.0.0", "queue": "^6.0.1", "yoga-layout": "^3.2.1" } }, "sha512-1V8ssgg9FHVsmvuCKmp7TWoUiPGgxAR2cgyvdcao8UQm7emWB7rP1o4CieHH56kgZyXXbwWqQAmmtgvcju+xfA=="],
 
     "@react-pdf/pdfkit": ["@react-pdf/pdfkit@5.0.0", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@noble/ciphers": "^1.0.0", "@noble/hashes": "^1.6.0", "@react-pdf/png-js": "^3.0.0", "browserify-zlib": "^0.2.0", "fontkit": "^2.0.2", "jay-peg": "^1.1.1", "js-md5": "^0.8.3", "linebreak": "^1.1.0", "vite-compatible-readable-stream": "^3.6.1" } }, "sha512-FcQBWGtfhMGuOB0G3NcnF/cBq/JnFVs22i1tuafiT1XlmG6KjCxgTGng5bVh+b9RtTuwNpUGmCtB6CmG6B4ZVA=="],
 
@@ -439,13 +439,13 @@
 
     "@react-pdf/reconciler": ["@react-pdf/reconciler@2.0.0", "", { "dependencies": { "object-assign": "^4.1.1", "scheduler": "0.25.0-rc-603e6108-20241029" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw=="],
 
-    "@react-pdf/render": ["@react-pdf/render@4.4.0", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/primitives": "^4.2.0", "@react-pdf/textkit": "^6.1.1", "@react-pdf/types": "^2.10.0", "abs-svg-path": "^0.1.1", "color-string": "^1.9.1", "normalize-svg-path": "^1.1.0", "parse-svg-path": "^0.1.2", "svg-arc-to-cubic-bezier": "^3.2.0" } }, "sha512-+gGa9ymGosN6Ld3hFFSIVCV03Vva5S+asW7vmKetZY4LnhX5ea2gYNy6wL3e9VsLHqFDAefIXGtGDLH6XxQHag=="],
+    "@react-pdf/render": ["@react-pdf/render@4.4.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/primitives": "^4.2.0", "@react-pdf/textkit": "^6.2.0", "@react-pdf/types": "^2.10.0", "abs-svg-path": "^0.1.1", "color-string": "^1.9.1", "normalize-svg-path": "^1.1.0", "parse-svg-path": "^0.1.2", "svg-arc-to-cubic-bezier": "^3.2.0" } }, "sha512-TBaEw6F+IBI4oVHUF7LL2OJX87unRrk6r7mkEmgjehN9BV5LF53I8CzVtdAchuO1+YhvE4MoMzkNelA+X2luRA=="],
 
-    "@react-pdf/renderer": ["@react-pdf/renderer@4.4.0", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/font": "^4.0.6", "@react-pdf/layout": "^4.5.0", "@react-pdf/pdfkit": "^5.0.0", "@react-pdf/primitives": "^4.2.0", "@react-pdf/reconciler": "^2.0.0", "@react-pdf/render": "^4.4.0", "@react-pdf/types": "^2.10.0", "events": "^3.3.0", "object-assign": "^4.1.1", "prop-types": "^15.6.2", "queue": "^6.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-TtCcz1vyYD6fddhvBagwr9Aj3gRFLCqvduERQyNhTzHJi3zAKayHvJFr2PxcP4sRyIDRhibDW6ApqNhTqIVPoQ=="],
+    "@react-pdf/renderer": ["@react-pdf/renderer@4.4.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/font": "^4.0.6", "@react-pdf/layout": "^4.5.1", "@react-pdf/pdfkit": "^5.0.0", "@react-pdf/primitives": "^4.2.0", "@react-pdf/reconciler": "^2.0.0", "@react-pdf/render": "^4.4.1", "@react-pdf/types": "^2.10.0", "events": "^3.3.0", "object-assign": "^4.1.1", "prop-types": "^15.6.2", "queue": "^6.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mK7xyCdDUagO1kg8jraad3aUzdVAGBru08qyjjp8FMhGsh4BcuPGa0SycQ8Pv8EDEdyEOfmiE+XI1sBybSLwaQ=="],
 
     "@react-pdf/stylesheet": ["@react-pdf/stylesheet@6.1.4", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "@react-pdf/types": "^2.10.0", "color-string": "^1.9.1", "hsl-to-hex": "^1.0.0", "media-engine": "^1.0.3", "postcss-value-parser": "^4.1.0" } }, "sha512-jiwovO7lUwgccAh3JbVcXnh90AiSKZetdz2ETcWsKApPPLzLUzPkEs6wCVvZqh3lcGOAPFV3AfdMkFnLwv1ryg=="],
 
-    "@react-pdf/textkit": ["@react-pdf/textkit@6.1.1", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "bidi-js": "^1.0.2", "hyphen": "^1.6.4", "unicode-properties": "^1.4.1" } }, "sha512-HAHoa407q0UHLzwe/oL6VwgJj2cGKs5vORSVY+cRG/GC0kt7nxUV9N+2hA6VcqJA37gSRg7BTLsVr8Tt+4l5ow=="],
+    "@react-pdf/textkit": ["@react-pdf/textkit@6.2.0", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "bidi-js": "^1.0.2", "hyphen": "^1.6.4", "unicode-properties": "^1.4.1" } }, "sha512-0B22Kue/ALHiEcYNbrx2BdkpHPTq2j3u2xmAyCnf3XJbTyANjljJjtWRohkVLQKqOlieD88BvmQt7OeWLj+ZYg=="],
 
     "@react-pdf/types": ["@react-pdf/types@2.10.0", "", { "dependencies": { "@react-pdf/font": "^4.0.6", "@react-pdf/primitives": "^4.2.0", "@react-pdf/stylesheet": "^6.1.4" } }, "sha512-iz0NusqQ/9ZHQirWhJqOaxY1UkpvuNkEDtH4/SPCnhZJKBO/IhlFLFHuzbHkmWByBoX6X3m8GCc2b/1QH6QNlA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.6",
-    "@react-pdf/renderer": "^4.4.0",
+    "@react-pdf/renderer": "^4.4.1",
     "@tanstack/react-query": "^5.97.0",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- upgrade `@react-pdf/renderer` from `4.4.0` to `4.4.1`
- bump `.github/workflows/update-umami-tracker.yml` from `peter-evans/create-pull-request@v8.1.0` to `v8.1.1`
- keep the change scoped to dependency maintenance; no source changes were required

## Release triage
- `@react-pdf/renderer@4.4.1` is a patch release published on April 10, 2026. Upstream notes describe a render-layer border rendering fix and matching dependency bumps to `@react-pdf/render@4.4.1` and `@react-pdf/layout@4.5.1`.
- This repo uses `@react-pdf/renderer` in `scripts/cv/CVDocument.tsx` and `scripts/generate-cv-assets.ts`. Validation and visual comparison stayed green, so no code changes were needed.
- `peter-evans/create-pull-request@v8.1.1` is a patch release published on April 10, 2026. The notable functional change is retrying post-creation API calls on transient GitHub 422 eventual-consistency errors.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bunx -y react-doctor@latest . --diff main --offline`
- `bun run build`

## Visual regression
- Before/after captures taken for `/de` hero, about, experience, and projects, plus `/de/imprint`, `/de/privacy`, and `/de/cv`
- Compare result: all 7 targets passed with `changed=0`
- Artifact root: `/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.B4J2bOXlBJ`
- Accepted visual drift: none

## Follow-ups
- No follow-up issues were needed for this patch-level upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PDF rendering library to latest patch version.
  * Updated GitHub Actions workflow automation to latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->