### PR TITLE
chore(deps): upgrade react-query and stabilize hero visual regression

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.6",
         "@react-pdf/renderer": "^4.4.1",
-        "@tanstack/react-query": "^5.97.0",
+        "@tanstack/react-query": "^5.99.0",
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -487,9 +487,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "postcss": "^8.5.6", "tailwindcss": "4.2.2" } }, "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.97.0", "", {}, "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.99.0", "", {}, "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.97.0", "", { "dependencies": { "@tanstack/query-core": "5.97.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.99.0", "", { "dependencies": { "@tanstack/query-core": "5.99.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.6",
     "@react-pdf/renderer": "^4.4.1",
-    "@tanstack/react-query": "^5.97.0",
+    "@tanstack/react-query": "^5.99.0",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -207,7 +207,7 @@ const HeroSection = () => {
   }, [updateMagicRingPosition]);
 
   // FitText Hook for dynamic title
-  const currentTitle = t(hero.titleElements[titleIndex]);
+  const currentTitle = isVisualRegression ? t(hero.titleElements[0]) : t(hero.titleElements[titleIndex]);
   const { fontSize, ref: fitTextRef } = useFitText({
     depKey: currentTitle,
     maxFontSize: 48,


### PR DESCRIPTION
## Summary
- upgrade `@tanstack/react-query` from `5.97.0` to `5.99.0`
- refresh `bun.lock` for `@tanstack/query-core@5.99.0`
- make the hero subtitle deterministic during visual-regression mode so the dependency screenshot flow stops failing on unrelated title rotation

## Release triage
- `@tanstack/react-query@5.99.0` was published on April 11, 2026 and only notes an updated `@tanstack/query-core@5.99.0` patch dependency
- package usage in this repo is limited to the shared query client provider in `src/app/providers.client.tsx`
- no follow-up issues were needed

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bunx -y react-doctor@latest . --diff main --offline`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bunx -y react-doctor@latest . --diff main --offline`
- `bun run build`

## Visual regression
- before/after German capture completed for: hero, about, experience, projects, imprint, privacy, and CV
- final compare passed across all 7 targets using artifact root `/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.5e4fEIsZew`
- the initial compare failed only because the hero subtitle rotated between baseline runs (`KI-Enthusiast` vs `Security-Engineer`); this PR fixes that test flake by pinning the first title in visual-regression mode

## Workflow actions checked
- `.github/workflows/update-umami-tracker.yml` already uses current latest releases for `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React Query dependency to v5.99.0.

* **Bug Fixes**
  * Improved consistency of hero section title rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->