### PR TITLE
[#97] Add agent discovery headers and markdown negotiation

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,5 +12,6 @@ Allow: /
 
 User-agent: *
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=no
 
 Sitemap: https://uweschwarz.eu/sitemap.xml

--- a/src/app/api/agent-markdown/route.test.js
+++ b/src/app/api/agent-markdown/route.test.js
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("agent markdown route", () => {
+  test("returns a controlled 500 response when markdown generation fails", async () => {
+    mock.module("@/lib/agent-readiness", () => ({
+      appendAgentDiscoveryHeaders(headers) {
+        headers.append("Link", '</llms.txt>; rel="describedby"; type="text/plain"');
+      },
+      buildHomepageMarkdown() {
+        throw new Error("boom");
+      },
+      buildMarkdownResponseHeaders() {
+        return new globalThis.Headers({
+          "Content-Type": "text/markdown; charset=utf-8",
+          "x-markdown-tokens": "0",
+        });
+      },
+    }));
+
+    const { GET } = await import("@/app/api/agent-markdown/route");
+    const response = await GET(new globalThis.Request("https://uweschwarz.eu/api/agent-markdown?lang=en"));
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).toBe("Unable to build markdown response");
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("content-language")).toBe("en");
+    expect(response.headers.get("link")).toContain('rel="describedby"');
+  });
+});

--- a/src/app/api/agent-markdown/route.ts
+++ b/src/app/api/agent-markdown/route.ts
@@ -1,0 +1,22 @@
+import { DEFAULT_LANGUAGE, isSupportedLanguage } from "@/lib/i18n";
+import {
+  appendAgentDiscoveryHeaders,
+  buildHomepageMarkdown,
+  buildMarkdownResponseHeaders,
+} from "@/lib/agent-readiness";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const requestedLanguage = searchParams.get("lang");
+  const language = isSupportedLanguage(requestedLanguage) ? requestedLanguage : DEFAULT_LANGUAGE;
+  const markdown = buildHomepageMarkdown(language);
+  const headers = buildMarkdownResponseHeaders(markdown);
+
+  headers.set("Content-Language", language);
+  appendAgentDiscoveryHeaders(headers);
+
+  return new Response(markdown, {
+    headers,
+    status: 200,
+  });
+}

--- a/src/app/api/agent-markdown/route.ts
+++ b/src/app/api/agent-markdown/route.ts
@@ -9,14 +9,29 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const requestedLanguage = searchParams.get("lang");
   const language = isSupportedLanguage(requestedLanguage) ? requestedLanguage : DEFAULT_LANGUAGE;
-  const markdown = buildHomepageMarkdown(language);
-  const headers = buildMarkdownResponseHeaders(markdown);
 
-  headers.set("Content-Language", language);
-  appendAgentDiscoveryHeaders(headers);
+  try {
+    const markdown = buildHomepageMarkdown(language);
+    const headers = buildMarkdownResponseHeaders(markdown);
 
-  return new Response(markdown, {
-    headers,
-    status: 200,
-  });
+    headers.set("Content-Language", language);
+    appendAgentDiscoveryHeaders(headers);
+
+    return new Response(markdown, {
+      headers,
+      status: 200,
+    });
+  } catch {
+    const headers = new Headers({
+      "Content-Language": language,
+      "Content-Type": "text/plain; charset=utf-8",
+    });
+
+    appendAgentDiscoveryHeaders(headers);
+
+    return new Response("Unable to build markdown response", {
+      headers,
+      status: 500,
+    });
+  }
 }

--- a/src/lib/agent-readiness.test.js
+++ b/src/lib/agent-readiness.test.js
@@ -7,21 +7,27 @@ import {
   buildMarkdownResponseHeaders,
   hasMarkdownAcceptHeader,
   isHomepagePath,
-} from "./agent-readiness.ts";
+} from "@/lib/agent-readiness";
 
 describe("agent readiness helpers", () => {
   test("marks only homepage routes as eligible for agent negotiation", () => {
     expect(isHomepagePath("/")).toBe(true);
     expect(isHomepagePath("/en")).toBe(true);
     expect(isHomepagePath("/de")).toBe(true);
+    expect(isHomepagePath("/en/")).toBe(true);
+    expect(isHomepagePath("/de///")).toBe(true);
 
     expect(isHomepagePath("/en/cv")).toBe(false);
     expect(isHomepagePath("/privacy")).toBe(false);
   });
 
-  test("recognizes markdown accept negotiation without treating q=0 as acceptable", () => {
+  test("recognizes markdown accept negotiation only when markdown is not lower priority", () => {
     expect(hasMarkdownAcceptHeader("text/markdown")).toBe(true);
-    expect(hasMarkdownAcceptHeader("text/html, text/markdown;q=0.8")).toBe(true);
+    expect(hasMarkdownAcceptHeader("text/html, text/markdown;q=0.8")).toBe(false);
+    expect(hasMarkdownAcceptHeader("text/html;q=0.5, text/markdown;q=0.8")).toBe(true);
+    expect(hasMarkdownAcceptHeader("text/html;q=0.8, text/markdown;q=0.8")).toBe(true);
+    expect(hasMarkdownAcceptHeader("text/html;q=1, text/markdown;q=0.1")).toBe(false);
+    expect(hasMarkdownAcceptHeader("*/*;q=1, text/markdown;q=0.8")).toBe(false);
     expect(hasMarkdownAcceptHeader("text/markdown;q=0")).toBe(false);
     expect(hasMarkdownAcceptHeader("text/html")).toBe(false);
     expect(hasMarkdownAcceptHeader(null)).toBe(false);
@@ -37,7 +43,7 @@ describe("agent readiness helpers", () => {
     expect(AGENT_DISCOVERY_LINKS.join(",")).toContain("</llms.txt>");
     expect(AGENT_DISCOVERY_LINKS.join(",")).toContain("</sitemap>");
 
-    const headers = new Headers();
+    const headers = new globalThis.Headers();
     appendAgentDiscoveryHeaders(headers);
 
     expect(headers.get("link")).toContain('rel="describedby"');

--- a/src/lib/agent-readiness.test.js
+++ b/src/lib/agent-readiness.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AGENT_DISCOVERY_LINKS,
+  appendAgentDiscoveryHeaders,
+  buildHomepageMarkdown,
+  buildMarkdownResponseHeaders,
+  hasMarkdownAcceptHeader,
+  isHomepagePath,
+} from "./agent-readiness.ts";
+
+describe("agent readiness helpers", () => {
+  test("marks only homepage routes as eligible for agent negotiation", () => {
+    expect(isHomepagePath("/")).toBe(true);
+    expect(isHomepagePath("/en")).toBe(true);
+    expect(isHomepagePath("/de")).toBe(true);
+
+    expect(isHomepagePath("/en/cv")).toBe(false);
+    expect(isHomepagePath("/privacy")).toBe(false);
+  });
+
+  test("recognizes markdown accept negotiation without treating q=0 as acceptable", () => {
+    expect(hasMarkdownAcceptHeader("text/markdown")).toBe(true);
+    expect(hasMarkdownAcceptHeader("text/html, text/markdown;q=0.8")).toBe(true);
+    expect(hasMarkdownAcceptHeader("text/markdown;q=0")).toBe(false);
+    expect(hasMarkdownAcceptHeader("text/html")).toBe(false);
+    expect(hasMarkdownAcceptHeader(null)).toBe(false);
+  });
+
+  test("advertises agent-useful homepage links with registered relation types", () => {
+    expect(AGENT_DISCOVERY_LINKS).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('rel="describedby"'),
+        expect.stringContaining('rel="service-doc"'),
+      ]),
+    );
+    expect(AGENT_DISCOVERY_LINKS.join(",")).toContain("</llms.txt>");
+    expect(AGENT_DISCOVERY_LINKS.join(",")).toContain("</sitemap>");
+
+    const headers = new Headers();
+    appendAgentDiscoveryHeaders(headers);
+
+    expect(headers.get("link")).toContain('rel="describedby"');
+    expect(headers.get("link")).toContain('rel="service-doc"');
+  });
+
+  test("renders homepage markdown with markdown-specific response headers", () => {
+    const markdown = buildHomepageMarkdown("en");
+    const headers = buildMarkdownResponseHeaders(markdown);
+
+    expect(markdown).toContain("# Uwe Schwarz");
+    expect(markdown).toContain("## About");
+    expect(markdown).toContain("## Skills");
+    expect(markdown).toContain("## Contact");
+    expect(headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(Number(headers.get("x-markdown-tokens"))).toBeGreaterThan(100);
+  });
+});

--- a/src/lib/agent-readiness.ts
+++ b/src/lib/agent-readiness.ts
@@ -119,18 +119,30 @@ export function hasMarkdownAcceptHeader(acceptHeader: string | null) {
     return false;
   }
 
-  return acceptHeader.split(",").some((part) => {
+  const acceptedTypes = acceptHeader.split(",").map((part) => {
     const [typePart, ...parameterParts] = part.split(";").map((value) => value.trim().toLowerCase());
-
-    if (typePart !== "text/markdown") {
-      return false;
-    }
-
     const qValue = parameterParts.find((parameter) => parameter.startsWith("q="));
-    return qValue ? Number(qValue.slice(2)) > 0 : true;
+    const q = qValue ? Number(qValue.slice(2)) : 1;
+
+    return {
+      q: Number.isFinite(q) ? q : 0,
+      type: typePart,
+    };
   });
+
+  const markdownQ = Math.max(0, ...acceptedTypes.filter(({ type }) => type === "text/markdown").map(({ q }) => q));
+  const htmlCompatibleQ = Math.max(
+    0,
+    ...acceptedTypes
+      .filter(({ type }) => type === "text/html" || type === "text/*" || type === "*/*")
+      .map(({ q }) => q),
+  );
+
+  return markdownQ > 0 && markdownQ >= htmlCompatibleQ;
 }
 
 export function isHomepagePath(pathname: string) {
-  return HOMEPAGE_PATHS.has(pathname);
+  const normalizedPathname = pathname === "/" ? pathname : pathname.replace(/\/+$/, "");
+
+  return HOMEPAGE_PATHS.has(normalizedPathname || "/");
 }

--- a/src/lib/agent-readiness.ts
+++ b/src/lib/agent-readiness.ts
@@ -1,0 +1,136 @@
+import { siteContent } from "@/content/content";
+import type { Language } from "@/contexts/settings-hook";
+import { translateLocalizedString } from "@/lib/localization";
+
+const HOMEPAGE_PATHS = new Set(["/", "/de", "/en"]);
+const SECTION_TITLES = {
+  about: { de: "Ueber mich", en: "About" },
+  contact: { de: "Kontakt", en: "Contact" },
+  experience: { de: "Erfahrung", en: "Experience" },
+  projects: { de: "Projekte", en: "Projects" },
+  resources: { de: "Ressourcen", en: "Resources" },
+  skills: { de: "Faehigkeiten", en: "Skills" },
+} as const;
+
+export const AGENT_DISCOVERY_LINKS = [
+  '</llms.txt>; rel="describedby"; type="text/plain"',
+  '</sitemap>; rel="service-doc"; type="text/html"',
+];
+
+function localize(value: { de: string; en: string }, language: Language) {
+  return translateLocalizedString(value, language);
+}
+
+function formatAvailability(language: Language) {
+  const { availability } = siteContent.hero;
+  const currentLine = localize(availability.currentLine, language).replace(
+    "{percent}",
+    String(availability.currentPercentAvailable),
+  );
+  const fullLine = localize(availability.fullLine, language).replace("{date}", availability.fullyAvailableDate);
+
+  return `${localize(availability.title, language)}: ${currentLine}, ${fullLine}`;
+}
+
+function estimateMarkdownTokens(markdown: string) {
+  return markdown.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export function appendAgentDiscoveryHeaders(headers: Headers) {
+  for (const linkHeader of AGENT_DISCOVERY_LINKS) {
+    headers.append("Link", linkHeader);
+  }
+}
+
+export function buildHomepageMarkdown(language: Language) {
+  const topSkills = siteContent.skills.slice(0, 12).map((skill) => localize(skill.name, language));
+  const featuredExperiences = siteContent.experiences.slice(0, 3);
+  const featuredProjects = siteContent.projects.slice(0, 4);
+  const heroTitle = siteContent.hero.titleElements.map((title) => localize(title, language)).join(" | ");
+
+  const lines = [
+    `# ${siteContent.hero.name}`,
+    "",
+    heroTitle,
+    "",
+    localize(siteContent.siteMetadata.description, language),
+    "",
+    localize(siteContent.hero.description, language),
+    "",
+    formatAvailability(language),
+    "",
+    `## ${localize(SECTION_TITLES.about, language)}`,
+    "",
+    ...siteContent.about.paragraphs.map((paragraph) => localize(paragraph, language)),
+    "",
+    `## ${localize(SECTION_TITLES.skills, language)}`,
+    "",
+    topSkills.map((skill) => `- ${skill}`).join("\n"),
+    "",
+    `## ${localize(SECTION_TITLES.experience, language)}`,
+    "",
+    ...featuredExperiences.flatMap((experience) => {
+      const firstDescription =
+        experience.description.find((item) => item.type === "text")?.text ?? experience.description[0]?.text;
+
+      return [
+        `- **${localize(experience.title, language)}**, ${experience.company} (${localize(experience.period, language)})`,
+        `  ${firstDescription ? localize(firstDescription, language) : ""}`,
+      ];
+    }),
+    "",
+    `## ${localize(SECTION_TITLES.projects, language)}`,
+    "",
+    ...featuredProjects.flatMap((project) => [
+      `- **${localize(project.title, language)}**`,
+      `  ${localize(project.description, language)}`,
+    ]),
+    "",
+    `## ${localize(SECTION_TITLES.contact, language)}`,
+    "",
+    `- ${localize(siteContent.contact.emailLabel, language)} ${siteContent.contact.email}`,
+    `- ${localize(siteContent.contact.phoneLabel, language)} ${siteContent.contact.phone}`,
+    `- GitHub: ${siteContent.contact.socialLinks.github ?? ""}`,
+    `- LinkedIn: ${siteContent.contact.socialLinks.linkedin ?? ""}`,
+    "",
+    `## ${localize(SECTION_TITLES.resources, language)}`,
+    "",
+    "- llms.txt: /llms.txt",
+    "- Sitemap: /sitemap",
+    "- Privacy: /privacy",
+    "- Imprint: /imprint",
+  ];
+
+  return `${lines.filter(Boolean).join("\n")}\n`;
+}
+
+export function buildMarkdownResponseHeaders(markdown: string) {
+  const headers = new Headers();
+
+  headers.set("Content-Type", "text/markdown; charset=utf-8");
+  headers.set("Vary", "Accept");
+  headers.set("x-markdown-tokens", String(estimateMarkdownTokens(markdown)));
+
+  return headers;
+}
+
+export function hasMarkdownAcceptHeader(acceptHeader: string | null) {
+  if (!acceptHeader) {
+    return false;
+  }
+
+  return acceptHeader.split(",").some((part) => {
+    const [typePart, ...parameterParts] = part.split(";").map((value) => value.trim().toLowerCase());
+
+    if (typePart !== "text/markdown") {
+      return false;
+    }
+
+    const qValue = parameterParts.find((parameter) => parameter.startsWith("q="));
+    return qValue ? Number(qValue.slice(2)) > 0 : true;
+  });
+}
+
+export function isHomepagePath(pathname: string) {
+  return HOMEPAGE_PATHS.has(pathname);
+}

--- a/src/proxy.test.js
+++ b/src/proxy.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 
-import { proxy } from "./proxy.ts";
+import { proxy } from "@/proxy";
 
 describe("proxy agent readiness behavior", () => {
   test("adds agent discovery link headers to homepage responses", () => {
@@ -22,5 +22,19 @@ describe("proxy agent readiness behavior", () => {
 
     expect(response.headers.get("x-middleware-rewrite")).toContain("/api/agent-markdown?lang=de");
     expect(response.headers.get("link")).toContain('rel="describedby"');
+  });
+
+  test("treats trailing-slash localized homepages like the homepage", () => {
+    const request = new NextRequest("https://uweschwarz.eu/en/", {
+      headers: {
+        accept: "text/markdown, text/html;q=0.8",
+      },
+    });
+    const response = proxy(request);
+    const rewriteTarget = response.headers.get("x-middleware-rewrite");
+
+    expect(rewriteTarget).toContain("/api/agent-markdown/");
+    expect(rewriteTarget).toContain("lang=en");
+    expect(response.headers.get("link")).toContain('rel="service-doc"');
   });
 });

--- a/src/proxy.test.js
+++ b/src/proxy.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { proxy } from "./proxy.ts";
+
+describe("proxy agent readiness behavior", () => {
+  test("adds agent discovery link headers to homepage responses", () => {
+    const request = new NextRequest("https://uweschwarz.eu/en");
+    const response = proxy(request);
+
+    expect(response.headers.get("link")).toContain('rel="describedby"');
+    expect(response.headers.get("link")).toContain('rel="service-doc"');
+  });
+
+  test("rewrites homepage markdown requests to the internal markdown route", () => {
+    const request = new NextRequest("https://uweschwarz.eu/de", {
+      headers: {
+        accept: "text/markdown, text/html;q=0.8",
+      },
+    });
+    const response = proxy(request);
+
+    expect(response.headers.get("x-middleware-rewrite")).toContain("/api/agent-markdown?lang=de");
+    expect(response.headers.get("link")).toContain('rel="describedby"');
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 import { detectPreferredLanguage } from "@/lib/detect-language";
+import { appendAgentDiscoveryHeaders, hasMarkdownAcceptHeader, isHomepagePath } from "@/lib/agent-readiness";
 import { DEFAULT_LANGUAGE, isSupportedLanguage, replacePathLanguage } from "@/lib/i18n";
 import { buildContentSecurityPolicy, createCspNonce, NONCE_HEADER, normalizeSecurityHeader } from "@/lib/security/csp";
 
@@ -32,6 +33,7 @@ export function proxy(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   const nonce = isProduction ? createCspNonce() : null;
   const csp = nonce ? normalizeSecurityHeader(buildContentSecurityPolicy(nonce)) : null;
+  const wantsMarkdown = isHomepagePath(pathname) && hasMarkdownAcceptHeader(request.headers.get("accept"));
 
   if (nonce && csp) {
     requestHeaders.set("Content-Security-Policy", csp);
@@ -40,6 +42,26 @@ export function proxy(request: NextRequest) {
 
   const firstSegment = pathname.split("/")[1];
   if (isSupportedLanguage(firstSegment)) {
+    if (wantsMarkdown) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/api/agent-markdown";
+      url.searchParams.set("lang", firstSegment);
+
+      const response = NextResponse.rewrite(url, {
+        request: {
+          headers: requestHeaders,
+        },
+      });
+
+      if (nonce) {
+        applySecurityHeaders(response, nonce);
+      }
+
+      appendAgentDiscoveryHeaders(response.headers);
+
+      return response;
+    }
+
     const response = NextResponse.next({
       request: {
         headers: requestHeaders,
@@ -48,6 +70,10 @@ export function proxy(request: NextRequest) {
 
     if (nonce) {
       applySecurityHeaders(response, nonce);
+    }
+
+    if (isHomepagePath(pathname)) {
+      appendAgentDiscoveryHeaders(response.headers);
     }
 
     return response;
@@ -63,6 +89,32 @@ export function proxy(request: NextRequest) {
   const url = request.nextUrl.clone();
   url.pathname = replacePathLanguage(pathname, language);
 
+  if (wantsMarkdown) {
+    url.pathname = "/api/agent-markdown";
+    url.searchParams.set("lang", language);
+
+    const response = NextResponse.rewrite(url, {
+      request: {
+        headers: requestHeaders,
+      },
+    });
+
+    if (nonce) {
+      applySecurityHeaders(response, nonce);
+    }
+
+    appendAgentDiscoveryHeaders(response.headers);
+    response.cookies.set({
+      maxAge: 60 * 60 * 24 * 365,
+      name: "language",
+      path: "/",
+      sameSite: "lax",
+      value: language,
+    });
+
+    return response;
+  }
+
   const response = NextResponse.redirect(url);
 
   if (nonce) {
@@ -76,6 +128,10 @@ export function proxy(request: NextRequest) {
     sameSite: "lax",
     value: language,
   });
+
+  if (isHomepagePath(pathname)) {
+    appendAgentDiscoveryHeaders(response.headers);
+  }
 
   return response;
 }


### PR DESCRIPTION
Closes #97

## Summary
- add homepage `Link` response headers with agent-useful registered relation types
- serve a markdown homepage representation for `Accept: text/markdown` requests via proxy negotiation and an internal route
- declare AI content preferences in `robots.txt` with `Content-Signal`

## Testing
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run format:check` ✅
- `bunx -y react-doctor@latest . --diff main --offline` ✅
- `bun test src/lib/agent-readiness.test.js src/proxy.test.js` ✅
- `bun run build` ✅
- local smoke checks with `curl` against `next start` ✅

## Preview Validation
- Preview: https://uweschwarz-eu-git-codex-97-add-agent-discovery-he-7c42d7-e38383.vercel.app
- `curl -d '{"url":"https://uweschwarz-eu-git-codex-97-add-agent-discovery-he-7c42d7-e38383.vercel.app"}' https://isitagentready.com/api/scan` ✅
- `checks.discoverability.linkHeaders` → `pass`
- `checks.contentAccessibility.markdownNegotiation` → `pass`
- `checks.botAccessControl.contentSignals` → `pass`
