### PR TITLE
chore(deps): upgrade lucide-react to 1.11.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "docx": "^9.6.1",
         "embla-carousel-react": "^8.6.0",
         "geist": "^1.7.0",
-        "lucide-react": "^1.9.0",
+        "lucide-react": "^1.11.0",
         "motion": "^12.38.0",
         "next": "^16.2.4",
         "react": "^19.2.5",
@@ -775,7 +775,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@1.9.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA=="],
+    "lucide-react": ["lucide-react@1.11.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "docx": "^9.6.1",
     "embla-carousel-react": "^8.6.0",
     "geist": "^1.7.0",
-    "lucide-react": "^1.9.0",
+    "lucide-react": "^1.11.0",
     "motion": "^12.38.0",
     "next": "^16.2.4",
     "react": "^19.2.5",


### PR DESCRIPTION
## Summary

- Upgraded `lucide-react` from `^1.9.0` to `^1.11.0`.
- Regenerated `bun.lock` with Bun.
- Checked GitHub Actions workflow action versions; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already current.

## Release-note triage

- `lucide-react` 1.11.0 adds new/updated icons and package-internal fixes. This repo imports existing icons only, so no source changes were required.
- No follow-up issues were needed.

## Validation

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bunx -y react-doctor@latest . --diff main --offline`
- [x] `bun run build`
- [x] `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.GS0gTbSL96/before"`
- [x] `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.GS0gTbSL96/after"`
- [x] `bun run deps:visual -- compare --before-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.GS0gTbSL96/before" --after-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.GS0gTbSL96/after" --output-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.GS0gTbSL96/report"`

## Visual regression

All seven German targets passed with `changed=0` pixels:

- `/de` hero
- `/de` about
- `/de` experience
- `/de#projects`
- `/de/imprint`
- `/de/privacy`
- `/de/cv`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to maintain compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->