### PR TITLE
chore(deps): upgrade postcss to 8.5.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "pixelmatch": "^7.1.0",
         "playwright": "^1.59.1",
         "pngjs": "^7.0.0",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.12",
         "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
       },
@@ -66,6 +66,9 @@
   "trustedDependencies": [
     "sharp",
   ],
+  "overrides": {
+    "postcss": "8.5.12",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -851,7 +854,7 @@
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
-    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
@@ -1028,8 +1031,6 @@
     "docx/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "docx/nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
-
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 

--- a/package.json
+++ b/package.json
@@ -73,9 +73,12 @@
     "pixelmatch": "^7.1.0",
     "playwright": "^1.59.1",
     "pngjs": "^7.0.0",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.12",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   },
   "trustedDependencies": [
     "@swc/core",


### PR DESCRIPTION
## Summary

- Upgraded `postcss` from `8.5.10` to `8.5.12` in `package.json` and `bun.lock`.
- Added a Bun `overrides.postcss` entry so transitive users, including `@tailwindcss/postcss` and Next's internal PostCSS resolution, resolve to the patched `8.5.12` version instead of keeping older nested copies.
- Checked GitHub Actions workflow references under `.github/workflows/*.yml`; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already the latest available releases.
- Reviewed the PostCSS 8.5.12 release notes: this is a security-focused patch fixing unsafe file reads via user-generated CSS and adding `opts.unsafeMap` for disabling the new checks. The repo uses PostCSS through Tailwind/PostCSS config and does not need source changes.

## Validation

- `bun run lint` - pass, 0 warnings/errors
- `bun run typecheck` - pass
- `bun run format:check` - pass
- `bunx -y react-doctor@latest . --diff main --offline` - pass, no changed source files so scan skipped
- `bun run build` - pass
- `bun pm why postcss` - pass, all PostCSS dependents resolve to `postcss@8.5.12`
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "$ARTIFACT_ROOT/before"` - pass before upgrade
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "$ARTIFACT_ROOT/after"` - pass after upgrade and override
- `bun run deps:visual -- compare --before-dir "$ARTIFACT_ROOT/before" --after-dir "$ARTIFACT_ROOT/after" --output-dir "$ARTIFACT_ROOT/report"` - pass

## Visual Regression

Compared all seven German targets: `/de` hero, about, experience, projects, `/de/imprint`, `/de/privacy`, and `/de/cv`.

Result: all targets had `changed=0`, so there is no accepted visual drift.

Artifact root for this run: `/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.GGlv2YRoC9`

## Follow-up Issues

None. No larger migration or optional adoption work was identified for this patch upgrade.
