### PR TITLE
chore(deps): upgrade dependencies to latest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "docx": "^9.6.1",
         "embla-carousel-react": "^8.6.0",
         "geist": "^1.7.0",
-        "lucide-react": "^1.12.0",
+        "lucide-react": "^1.14.0",
         "motion": "^12.38.0",
         "next": "^16.2.4",
         "react": "^19.2.5",
@@ -36,7 +36,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.184.0",
-        "zod": "^4.3.6",
+        "zod": "^4.4.1",
       },
       "devDependencies": {
         "@nkzw/eslint-plugin": "^2.0.0",
@@ -46,7 +46,7 @@
         "@types/react": "^19.2.14",
         "@types/three": "^0.184.0",
         "autoprefixer": "^10.5.0",
-        "eslint-plugin-no-only-tests": "^3.3.0",
+        "eslint-plugin-no-only-tests": "^3.4.0",
         "eslint-plugin-perfectionist": "^5.9.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
@@ -54,7 +54,7 @@
         "oxfmt": "^0.47.0",
         "oxlint": "^1.62.0",
         "oxlint-tsgolint": "^0.22.1",
-        "pixelmatch": "^7.1.1",
+        "pixelmatch": "^7.2.0",
         "playwright": "^1.59.1",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.12",
@@ -620,7 +620,7 @@
 
     "eslint": ["eslint@10.0.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.0", "@eslint/config-helpers": "^0.5.2", "@eslint/core": "^1.1.0", "@eslint/plugin-kit": "^0.6.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.0", "eslint-visitor-keys": "^5.0.0", "espree": "^11.1.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.1.1", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg=="],
 
-    "eslint-plugin-no-only-tests": ["eslint-plugin-no-only-tests@3.3.0", "", {}, "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q=="],
+    "eslint-plugin-no-only-tests": ["eslint-plugin-no-only-tests@3.4.0", "", {}, "sha512-4S3/9Nb7A2tiMcpzEQE9bQSlpeOz6WJkgryBuou/SA8W2x2c8Zf4j0NvTKBjv6qNhF9T79tmkecm/0CHqV0UGg=="],
 
     "eslint-plugin-perfectionist": ["eslint-plugin-perfectionist@5.9.0", "", { "dependencies": { "@typescript-eslint/utils": "^8.58.2", "natural-orderby": "^5.0.0" }, "peerDependencies": { "eslint": "^8.45.0 || ^9.0.0 || ^10.0.0" } }, "sha512-8TWzg02zmnBdZwCkWLi8jhzqXI+fE7Z/RwV8SL6xD45tJ8Bp3wGuYL2XtQgfe/Wd0eBqOUX+s6ey73IyszvKTA=="],
 
@@ -778,7 +778,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@1.12.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-rTKR3RN6HIAxdNZALoPvqxd64vjL9nTThU0JF9q1Qg8yUnmo1r+d8baN72YNVK3RGxUmzBzbd77IWJq/fkm+Xw=="],
+    "lucide-react": ["lucide-react@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -842,7 +842,7 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "pixelmatch": ["pixelmatch@7.1.1", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-ug6CkUcHtxn0umoaqV1VB9+h7IMxRgKQQ/fq4W7ahMnyzDSvQ0vsJRo6BC5s+Gv+RvpriWosDcGkI3L8+8Yxbw=="],
+    "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
 
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
@@ -986,13 +986,15 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "@babel/helper-compilation-targets/browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@nkzw/oxlint-config/eslint-plugin-no-only-tests": ["eslint-plugin-no-only-tests@3.3.0", "", {}, "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1031,6 +1033,8 @@
     "docx/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "docx/nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
+
+    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "docx": "^9.6.1",
     "embla-carousel-react": "^8.6.0",
     "geist": "^1.7.0",
-    "lucide-react": "^1.12.0",
+    "lucide-react": "^1.14.0",
     "motion": "^12.38.0",
     "next": "^16.2.4",
     "react": "^19.2.5",
@@ -52,7 +52,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.184.0",
-    "zod": "^4.3.6"
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@nkzw/eslint-plugin": "^2.0.0",
@@ -62,7 +62,7 @@
     "@types/react": "^19.2.14",
     "@types/three": "^0.184.0",
     "autoprefixer": "^10.5.0",
-    "eslint-plugin-no-only-tests": "^3.3.0",
+    "eslint-plugin-no-only-tests": "^3.4.0",
     "eslint-plugin-perfectionist": "^5.9.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unused-imports": "^4.4.1",
@@ -70,7 +70,7 @@
     "oxfmt": "^0.47.0",
     "oxlint": "^1.62.0",
     "oxlint-tsgolint": "^0.22.1",
-    "pixelmatch": "^7.1.1",
+    "pixelmatch": "^7.2.0",
     "playwright": "^1.59.1",
     "pngjs": "^7.0.0",
     "postcss": "^8.5.12",

--- a/scripts/deps-visual-check.mjs
+++ b/scripts/deps-visual-check.mjs
@@ -260,7 +260,7 @@ async function stabilizePage(page, settleMs, timeoutMs) {
     const documentRef = globalThis.document;
 
     if ("fonts" in documentRef) {
-      await documentRef.fonts.ready;
+      await Promise.race([documentRef.fonts.ready, new Promise((resolve) => globalThis.setTimeout(resolve, 2000))]);
     }
   });
   await page.mouse.move(0, 0);
@@ -353,7 +353,8 @@ async function captureTargets(browser, baseUrl, outputDir, options, manifestTarg
   const timeoutMs = toInt(options["timeout-ms"], DEFAULT_TIMEOUT_MS);
 
   for (const targetGroup of groupTargetsByPath(language)) {
-    const { context } = await createBrowserContext(browser, {
+    const groupBrowser = await chromium.launch({ headless: true });
+    const { context } = await createBrowserContext(groupBrowser, {
       ...options,
       lang: language,
       theme,
@@ -396,6 +397,7 @@ async function captureTargets(browser, baseUrl, outputDir, options, manifestTarg
             if (shouldScrollIntoView) {
               await page.locator(target.captureSelector).scrollIntoViewIfNeeded();
             }
+
             await page.locator(target.captureSelector).waitFor({
               state: "visible",
               timeout: timeoutMs,
@@ -404,6 +406,7 @@ async function captureTargets(browser, baseUrl, outputDir, options, manifestTarg
               await page.locator(target.captureSelector).screenshot({
                 animations: "disabled",
                 path: path.join(outputDir, relativePath),
+                timeout: timeoutMs,
                 type: "png",
               });
             });
@@ -413,6 +416,7 @@ async function captureTargets(browser, baseUrl, outputDir, options, manifestTarg
                 animations: "disabled",
                 fullPage: true,
                 path: path.join(outputDir, relativePath),
+                timeout: timeoutMs,
                 type: "png",
               });
             });
@@ -436,6 +440,7 @@ async function captureTargets(browser, baseUrl, outputDir, options, manifestTarg
     } finally {
       await page.close().catch(() => {});
       await context.close().catch(() => {});
+      await groupBrowser.close().catch(() => {});
     }
   }
 }

--- a/scripts/deps-visual-check.mjs
+++ b/scripts/deps-visual-check.mjs
@@ -346,23 +346,27 @@ function groupTargetsByPath(language) {
   return [...groups.values()];
 }
 
-async function captureTargets(browser, baseUrl, outputDir, options, manifestTargets, language, theme) {
+async function captureTargets(baseUrl, outputDir, options, manifestTargets, language, theme) {
   const samples = toInt(options.samples, DEFAULT_SAMPLES);
   const settleMs = toInt(options["settle-ms"], DEFAULT_SETTLE_MS);
   const sampleDelayMs = toInt(options["sample-delay-ms"], DEFAULT_SAMPLE_DELAY_MS);
   const timeoutMs = toInt(options["timeout-ms"], DEFAULT_TIMEOUT_MS);
 
   for (const targetGroup of groupTargetsByPath(language)) {
-    const groupBrowser = await chromium.launch({ headless: true });
-    const { context } = await createBrowserContext(groupBrowser, {
-      ...options,
-      lang: language,
-      theme,
-    });
-    const page = await createCapturePage(context, { language, theme });
-    const targetUrl = joinUrl(baseUrl, targetGroup[0].targetPath);
+    let context;
+    let groupBrowser;
+    let page;
 
     try {
+      groupBrowser = await chromium.launch({ headless: true });
+      ({ context } = await createBrowserContext(groupBrowser, {
+        ...options,
+        lang: language,
+        theme,
+      }));
+      page = await createCapturePage(context, { language, theme });
+      const targetUrl = joinUrl(baseUrl, targetGroup[0].targetPath);
+
       await page.goto(targetUrl, {
         timeout: timeoutMs,
         waitUntil: "domcontentloaded",
@@ -438,9 +442,9 @@ async function captureTargets(browser, baseUrl, outputDir, options, manifestTarg
         writeStdout(`Captured ${target.id}`);
       }
     } finally {
-      await page.close().catch(() => {});
-      await context.close().catch(() => {});
-      await groupBrowser.close().catch(() => {});
+      await page?.close().catch(() => {});
+      await context?.close().catch(() => {});
+      await groupBrowser?.close().catch(() => {});
     }
   }
 }
@@ -454,31 +458,25 @@ async function runCapture(options) {
   const outputDir = resolveOutputDir(options["output-dir"], "deps-visual-capture");
   await ensureDir(outputDir);
 
-  const browser = await chromium.launch({ headless: true });
+  const language = normalizeLanguage(options.lang);
+  const theme = normalizeTheme(options.theme);
+  const manifestTargets = [];
 
-  try {
-    const language = normalizeLanguage(options.lang);
-    const theme = normalizeTheme(options.theme);
-    const manifestTargets = [];
+  await captureTargets(baseUrl, outputDir, options, manifestTargets, language, theme);
 
-    await captureTargets(browser, baseUrl, outputDir, options, manifestTargets, language, theme);
+  const manifest = {
+    baseUrl,
+    capturedAt: new Date().toISOString(),
+    language,
+    outputDir,
+    sampleCount: toInt(options.samples, DEFAULT_SAMPLES),
+    targets: manifestTargets.sort((left, right) => left.id.localeCompare(right.id)),
+    theme,
+  };
 
-    const manifest = {
-      baseUrl,
-      capturedAt: new Date().toISOString(),
-      language,
-      outputDir,
-      sampleCount: toInt(options.samples, DEFAULT_SAMPLES),
-      targets: manifestTargets.sort((left, right) => left.id.localeCompare(right.id)),
-      theme,
-    };
+  await writeJson(path.join(outputDir, "manifest.json"), manifest);
 
-    await writeJson(path.join(outputDir, "manifest.json"), manifest);
-
-    writeStdout(`Captured ${manifest.targets.length} targets into ${outputDir}`);
-  } finally {
-    await browser.close();
-  }
+  writeStdout(`Captured ${manifest.targets.length} targets into ${outputDir}`);
 }
 
 async function readManifest(manifestDir) {


### PR DESCRIPTION
## Summary
- Upgrade direct dependencies: `lucide-react` 1.12.0 -> 1.14.0 and `zod` 4.3.6 -> 4.4.1.
- Upgrade dev dependencies: `eslint-plugin-no-only-tests` 3.3.0 -> 3.4.0 and `pixelmatch` 7.1.1 -> 7.2.0.
- Harden `scripts/deps-visual-check.mjs` so visual captures do not stall on font readiness or page-group browser state, and so per-group browser cleanup is guarded if setup fails.

## Release-note triage
- `lucide-react`: React peer range still includes React 19; repo usage is icon components only.
- `zod`: repo usage remains standard schema parsing for contact form/API validation; no code migration needed.
- `eslint-plugin-no-only-tests`: lint rules still pass with the updated package.
- `pixelmatch`: visual diff harness continues to compare the existing PNG targets successfully.
- GitHub Actions workflow references were checked and are already current: `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, `peter-evans/create-pull-request@v8.1.1`.

## Validation
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bunx -y react-doctor@latest . --diff main --offline`
- [x] `bun run build`
- [x] `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --samples 1 --output-dir "$ARTIFACT_ROOT/before"`
- [x] `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --samples 1 --output-dir "$ARTIFACT_ROOT/after"`
- [x] `bun run deps:visual -- compare --before-dir "$ARTIFACT_ROOT/before" --after-dir "$ARTIFACT_ROOT/after" --output-dir "$ARTIFACT_ROOT/report"`
- [x] After review fix: same code/build gate plus visual compare with zero changed pixels in `$ARTIFACT_ROOT/report-review-2`.

## Visual regression
- Result: zero changed pixels for all 7 German targets: home hero, about, experience, projects, imprint, privacy, and CV.
- Artifact root: `/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.XrsmG67c2p`
