### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.8",
         "@react-pdf/renderer": "^4.5.1",
-        "@tanstack/react-query": "^5.100.6",
+        "@tanstack/react-query": "^5.100.7",
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -36,7 +36,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.184.0",
-        "zod": "^4.4.1",
+        "zod": "^4.4.2",
       },
       "devDependencies": {
         "@nkzw/eslint-plugin": "^2.0.0",
@@ -490,9 +490,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.4", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "postcss": "^8.5.6", "tailwindcss": "4.2.4" } }, "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.100.6", "", {}, "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.7", "", {}, "sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.100.6", "", { "dependencies": { "@tanstack/query-core": "5.100.6" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.7", "", { "dependencies": { "@tanstack/query-core": "5.100.7" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
@@ -986,7 +986,7 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+    "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.8",
     "@react-pdf/renderer": "^4.5.1",
-    "@tanstack/react-query": "^5.100.6",
+    "@tanstack/react-query": "^5.100.7",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -52,7 +52,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.184.0",
-    "zod": "^4.4.1"
+    "zod": "^4.4.2"
   },
   "devDependencies": {
     "@nkzw/eslint-plugin": "^2.0.0",


### PR DESCRIPTION
## Summary

- Upgrades `@tanstack/react-query` from 5.100.6 to 5.100.7.
- Upgrades `zod` from 4.4.1 to 4.4.2.
- Refreshes `bun.lock` with Bun 1.3.13.

## Release-note triage

- `@tanstack/react-query` 5.100.7 is a patch release that updates its `@tanstack/query-core` dependency to 5.100.7; no code changes were required for this repo's `QueryClientProvider` usage.
- `zod` 4.4.2 includes a preprocess optionality fix and documentation/tooling changes; this repo uses straightforward string/object/email parsing, so no compatibility changes were required.
- GitHub Actions workflow actions were checked and are already on latest releases: `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1`.

## Validation

- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run format:check` ✅
- `bunx -y react-doctor@latest . --diff main --offline` ✅ (no changed source files, skipped)
- `bun run build` ✅
- `bun run deps:visual` capture/compare ✅

## Visual regression

Captured before and after German-language states for `/de` hero, about, experience, projects, `/de/imprint`, `/de/privacy`, and `/de/cv`.

Result: zero changed pixels for all 7 targets. Report artifact root: `/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.0Lp0K4L8eg`.

## Follow-ups

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest patch versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->