### PR TITLE
[codex] Upgrade dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.8",
         "@react-pdf/renderer": "^4.5.1",
-        "@tanstack/react-query": "^5.100.8",
+        "@tanstack/react-query": "^5.100.9",
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -490,9 +490,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.4", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "postcss": "^8.5.6", "tailwindcss": "4.2.4" } }, "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.100.8", "", {}, "sha512-ceYwSFOqjPwET5TA6IOYxzxlGc0ekyH/gfOtWkP0PX43rzX9bxW48Iuw8KAduKCToi4rJAQ6nRy2kAe8gszdmg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.9", "", {}, "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.100.8", "", { "dependencies": { "@tanstack/query-core": "5.100.8" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-iNNEekixXU5vtAGKKZX2lx3jTooG5yNY+kv0wSgEdEYG0Mj0JM5bcuQtC35ZAP3nDopT6jciUK3xeX65U7AnfA=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.9", "", { "dependencies": { "@tanstack/query-core": "5.100.9" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.8",
     "@react-pdf/renderer": "^4.5.1",
-    "@tanstack/react-query": "^5.100.8",
+    "@tanstack/react-query": "^5.100.9",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- Upgrade `@tanstack/react-query` from `5.100.8` to `5.100.9`.
- Refresh `@tanstack/query-core` in `bun.lock` to `5.100.9`.

## Release-note triage
- `@tanstack/react-query@5.100.9` is an official patch release that updates its `@tanstack/query-core` dependency.
- The repo only initializes `QueryClient` / `QueryClientProvider`, so no code compatibility changes or follow-up issues were needed.
- GitHub Actions workflow pins were checked; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already the latest available releases.

## Validation
- `bun run lint` - pass
- `bun run typecheck` - pass
- `bun run format:check` - pass
- `bunx -y react-doctor@latest . --diff main --offline` - pass
- `bun run build` - pass
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir \"/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.v1mcvr51kB/before\"` - pass
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir \"/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.v1mcvr51kB/after\"` - pass
- `bun run deps:visual -- compare --before-dir \"/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.v1mcvr51kB/before\" --after-dir \"/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.v1mcvr51kB/after\" --output-dir \"/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.v1mcvr51kB/report\"` - pass, 0 changed pixels on all 7 targets

## Visual regression
- Artifact root: `/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.v1mcvr51kB`
- Compared German `/de` hero/about/experience/projects plus `/de/imprint`, `/de/privacy`, and `/de/cv`.
- Result: no visual drift detected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to the latest patch versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->