### PR TITLE
chore(deps): upgrade dependencies to latest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.184.0",
-        "zod": "^4.4.2",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@nkzw/eslint-plugin": "^2.0.0",
@@ -57,7 +57,7 @@
         "pixelmatch": "^7.2.0",
         "playwright": "^1.59.1",
         "pngjs": "^7.0.0",
-        "postcss": "^8.5.13",
+        "postcss": "^8.5.14",
         "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
       },
@@ -67,7 +67,7 @@
     "sharp",
   ],
   "overrides": {
-    "postcss": "8.5.13",
+    "postcss": "8.5.14",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -854,7 +854,7 @@
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
-    "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
@@ -986,7 +986,7 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.184.0",
-    "zod": "^4.4.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@nkzw/eslint-plugin": "^2.0.0",
@@ -73,12 +73,12 @@
     "pixelmatch": "^7.2.0",
     "playwright": "^1.59.1",
     "pngjs": "^7.0.0",
-    "postcss": "^8.5.13",
+    "postcss": "^8.5.14",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "postcss": "8.5.13"
+    "postcss": "8.5.14"
   },
   "trustedDependencies": [
     "@swc/core",


### PR DESCRIPTION
## Summary
- Upgrade zod from 4.4.2 to 4.4.3.
- Upgrade postcss from 8.5.13 to 8.5.14 and keep the existing override aligned so Bun resolves the full graph to the patched version.
- Checked GitHub Actions workflow references; actions/checkout, oven-sh/setup-bun, and peter-evans/create-pull-request are already on latest releases.

## Release-note triage
- zod 4.4.3 restores v4 absent-key catch/fallback/preprocess handling; no code changes required for this site.
- postcss 8.5.14 fixes a custom syntax regression; no code changes required beyond the version and override bump.
- No follow-up issues created.

## Validation
- bun run lint: pass
- bun run typecheck: pass
- bun run format:check: pass
- bunx -y react-doctor@latest . --diff main --offline: pass
- bun run build: pass
- node .agents/skills/upgrade-dependencies-pr/scripts/check-no-latest-specifiers.mjs /Users/uwe/dev/web/uweschwarz-eu: pass
- bun outdated: no outdated packages remaining
- bun pm why postcss: resolved graph uses postcss@8.5.14

## Visual regression
- Artifact root: /var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.mc8Ffl2pG5
- Captured German before/after targets: /de hero, /de about, /de experience, /de#projects, /de/imprint, /de/privacy, /de/cv.
- Compare result: pass; all seven targets changed=0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest patch versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->