### PR TITLE
chore(deps): upgrade tailwind-merge

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "react-icons": "^5.6.0",
         "resend": "^6.12.3",
         "sonner": "^2.0.7",
-        "tailwind-merge": "^3.5.0",
+        "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.184.0",
         "zod": "^4.4.3",
@@ -928,7 +928,7 @@
 
     "svix": ["svix@1.92.2", "", { "dependencies": { "standardwebhooks": "1.0.0" } }, "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ=="],
 
-    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-icons": "^5.6.0",
     "resend": "^6.12.3",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0",
+    "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.184.0",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Summary

- Upgrades `tailwind-merge` from `3.5.0` to `3.6.0` in `package.json` and `bun.lock`.
- Reviewed the `tailwind-merge` v3.6.0 release notes: this adds Tailwind CSS v4.3 support and readonly-array config support; no code changes were required for this repo's current `twMerge` usage.
- Checked GitHub Actions workflow pins; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already latest.

## Validation

- `bun run lint` - pass
- `bun run typecheck` - pass
- `bun run format:check` - pass
- `bunx -y react-doctor@latest . --diff main --offline` - pass
- `bun run build` - pass
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.tre5Y1WuDO/before"` - pass before upgrade
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.tre5Y1WuDO/after"` - pass after upgrade
- `bun run deps:visual -- compare --before-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.tre5Y1WuDO/before" --after-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.tre5Y1WuDO/after" --output-dir "/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.tre5Y1WuDO/report"` - pass, all 7 German targets changed 0 pixels

## Visual Regression

Artifact root: `/var/folders/4m/q_s039ks6lsbbk9810jl6btw0000gn/T/uwe-deps-visual-XXXXXX.tre5Y1WuDO`

Targets captured and compared:

- `/de` hero
- `/de` about
- `/de` experience
- `/de#projects`
- `/de/imprint`
- `/de/privacy`
- `/de/cv`

Result: zero pixel changes across all targets.

## Follow-ups

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to the latest compatible version for improved stability and performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uwe-schwarz/uweschwarz-eu/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->