### PR TITLE
chore(deps): bump geist from 1.7.0 to 1.7.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "clsx": "^2.1.1",
         "docx": "^9.6.1",
         "embla-carousel-react": "^8.6.0",
-        "geist": "^1.7.0",
+        "geist": "^1.7.1",
         "lucide-react": "^1.16.0",
         "motion": "^12.39.0",
         "next": "^16.2.6",
@@ -672,7 +672,7 @@
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "geist": ["geist@1.7.0", "", { "peerDependencies": { "next": ">=13.2.0" } }, "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ=="],
+    "geist": ["geist@1.7.1", "", { "peerDependencies": { "next": ">=13.2.0" } }, "sha512-XF8DM30ODhDu0Ng5S2kOS8j4ZkG/6z2fKWAiFJA7wG0Hc92ZXgjYLrwbD9bVU4nGVzwboPtG+QtaPGsfgnXLaA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "clsx": "^2.1.1",
     "docx": "^9.6.1",
     "embla-carousel-react": "^8.6.0",
-    "geist": "^1.7.0",
+    "geist": "^1.7.1",
     "lucide-react": "^1.16.0",
     "motion": "^12.39.0",
     "next": "^16.2.6",


### PR DESCRIPTION
## Summary

- Upgrades `geist` from `1.7.0` to `1.7.1`.
- Regenerates `bun.lock` with Bun.
- Checked `.github/workflows/update-umami-tracker.yml`; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already latest.

## Release-note triage

- `geist@1.7.1` is a patch rebuild that fixes unintended standard ligatures in Geist Mono code text. This repo imports Geist Sans, Mono, and Pixel in `src/app/layout.tsx` and maps them in `tailwind.config.ts`, so the fix is relevant but requires no local code change.
- No follow-up issues were needed.

## Validation

- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run format:check` ✅
- `bunx -y react-doctor@latest . --diff main --offline` ✅
- `bun run build` ✅
- `bun run deps:visual -- compare --before-dir /tmp/uwe-deps-visual-124RSu/before --after-dir /tmp/uwe-deps-visual-124RSu/after --output-dir /tmp/uwe-deps-visual-124RSu/report` ✅

## Visual regression

Captured German-language before/after screenshots for `/de` hero, about, experience, projects, plus `/de/imprint`, `/de/privacy`, and `/de/cv`.

Result: all seven targets passed with `changed=0`; no visual drift accepted.

Artifact root: `/tmp/uwe-deps-visual-124RSu`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated geist UI component library to version 1.7.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uwe-schwarz/uweschwarz-eu/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->