### PR TITLE
[codex] Upgrade dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.8",
         "@react-pdf/renderer": "^4.5.1",
-        "@tanstack/react-query": "^5.100.11",
+        "@tanstack/react-query": "^5.100.13",
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -490,9 +490,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.0", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "postcss": "^8.5.10", "tailwindcss": "4.3.0" } }, "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.100.11", "", {}, "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.13", "", {}, "sha512-mlKVKMTzZWGTKAC1CKOgt7axAjJ921emkEvYIp27I/PdP1yEYL/BteLY8iK35gn8hoYeKB4mgJ/ve3lrDI6/Fw=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.100.11", "", { "dependencies": { "@tanstack/query-core": "5.100.11" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.13", "", { "dependencies": { "@tanstack/query-core": "5.100.13" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-HSBr8CycQEAoXsJR7KNDawBnINJEJ96Eme8oE0hCXjyodE2I97vg3IDzDJBDu18LsbzpVVJcKo80eqLfVCykxw=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.8",
     "@react-pdf/renderer": "^4.5.1",
-    "@tanstack/react-query": "^5.100.11",
+    "@tanstack/react-query": "^5.100.13",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

- Upgrades `@tanstack/react-query` from `5.100.11` to `5.100.13`.
- Refreshes `@tanstack/query-core` from `5.100.11` to `5.100.13` through the lockfile.
- Checked `.github/workflows/update-umami-tracker.yml`; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already latest non-prerelease releases.

## Release-note triage

- `@tanstack/react-query@5.100.13` is a patch release that updates `@tanstack/query-core`.
- `@tanstack/query-core@5.100.13` drops its custom `NoInfer<T>` re-export in favor of TypeScript's built-in `NoInfer` for TS >= 5.4 generic assignability behavior.
- Repo usage is limited to `QueryClient` and `QueryClientProvider` in `src/app/providers.client.tsx`; no compatibility code changes were required.
- No follow-up issues were created.

## Validation

- `bun run lint` passed.
- `bun run typecheck` passed.
- `bun run format:check` passed.
- `bunx -y react-doctor@latest . --diff main --offline` passed; no changed source files to scan.
- `bun run build` passed.
- `node .agents/skills/upgrade-dependencies-pr/scripts/check-no-latest-specifiers.mjs /home/uwe/dev/web/uweschwarz-eu` passed.

## Visual Regression

Artifact root: `/tmp/uwe-deps-visual-3tY2S3`

- Captured before screenshots for German `/de` hero, about, experience, projects, plus `/de/imprint`, `/de/privacy`, and `/de/cv`.
- Captured after screenshots for the same targets.
- `bun run deps:visual -- compare --before-dir /tmp/uwe-deps-visual-3tY2S3/before --after-dir /tmp/uwe-deps-visual-3tY2S3/after --output-dir /tmp/uwe-deps-visual-3tY2S3/report` passed.
- Result: zero changed pixels across all seven targets; no accepted drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@tanstack/react-query` to the latest patch version, which may include bug fixes and stability improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uwe-schwarz/uweschwarz-eu/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->