### PR TITLE
chore(deps): upgrade dependencies to latest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "docx": "^9.6.1",
+        "docx": "^9.7.0",
         "embla-carousel-react": "^8.6.0",
         "geist": "^1.7.1",
         "lucide-react": "^1.16.0",
@@ -590,7 +590,7 @@
 
     "dfa": ["dfa@1.2.0", "", {}, "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="],
 
-    "docx": ["docx@9.6.1", "", { "dependencies": { "@types/node": "^25.2.3", "hash.js": "^1.1.7", "jszip": "^3.10.1", "nanoid": "^5.1.3", "xml": "^1.0.1", "xml-js": "^1.6.8" } }, "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ=="],
+    "docx": ["docx@9.7.0", "", { "dependencies": { "@types/node": "^25.2.3", "hash.js": "^1.1.7", "jszip": "^3.10.1", "nanoid": "^5.1.3", "xml": "^1.0.1", "xml-js": "^1.6.8" } }, "sha512-saDn+8rAtW9nPlWxDs31Kbb/hL+AhHQN2gktHkWwkj59u9htUXtpVMN1Z+cSoLGCAaeYpW7Qe9F5sU3aPdiy9w=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -1026,8 +1026,6 @@
 
     "brotli/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "docx/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
-
     "docx/nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
     "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -1045,7 +1043,5 @@
     "@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
-
-    "docx/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "docx": "^9.6.1",
+    "docx": "^9.7.0",
     "embla-carousel-react": "^8.6.0",
     "geist": "^1.7.1",
     "lucide-react": "^1.16.0",


### PR DESCRIPTION
## Summary
- Upgrade `docx` from 9.6.1 to 9.7.0 in `package.json` and `bun.lock`.
- No GitHub Actions workflow version bumps were needed; existing workflow actions are already at their latest releases (`actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, `peter-evans/create-pull-request@v8.1.1`).
- Release-note triage: `docx` 9.7.0 adds/fixes image track-change support, numbering style association, comment replies/resolved state, first-line character indents, page-size code handling, and embedded-font filenames. The current CV generator does not require code changes for these updates.

## Validation
- `bun run lint` - passed
- `bun run typecheck` - passed
- `bun run format:check` - passed
- `bunx -y react-doctor@latest . --diff main --offline` - passed; no changed source files to scan
- `bun run build` - passed
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-Z41knP/before` - passed before upgrade
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-Z41knP/after` - passed after upgrade
- `bun run deps:visual -- compare --before-dir /tmp/uwe-deps-visual-Z41knP/before --after-dir /tmp/uwe-deps-visual-Z41knP/after --output-dir /tmp/uwe-deps-visual-Z41knP/report` - passed

## Visual Regression
- Compared German home hero, about, experience, projects, imprint, privacy, and CV screenshots.
- Result: all targets passed with `changed=0`; no accepted visual drift.
- Artifact root: `/tmp/uwe-deps-visual-Z41knP`

## Follow-up Issues
- None created; no larger required or optional migration work was identified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `docx` library dependency to version 9.7.0 for improved stability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uwe-schwarz/uweschwarz-eu/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->