### PR TITLE
chore(deps): upgrade dependencies to latest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.76.1",
         "react-icons": "^5.6.0",
-        "resend": "^6.12.3",
+        "resend": "^6.12.4",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -892,7 +892,7 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "resend": ["resend@6.12.3", "", { "dependencies": { "postal-mime": "2.7.4", "svix": "1.92.2" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw=="],
+    "resend": ["resend@6.12.4", "", { "dependencies": { "postal-mime": "2.7.4", "standardwebhooks": "1.0.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg=="],
 
     "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
 
@@ -925,8 +925,6 @@
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "svg-arc-to-cubic-bezier": ["svg-arc-to-cubic-bezier@3.2.0", "", {}, "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="],
-
-    "svix": ["svix@1.92.2", "", { "dependencies": { "standardwebhooks": "1.0.0" } }, "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.76.1",
     "react-icons": "^5.6.0",
-    "resend": "^6.12.3",
+    "resend": "^6.12.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary

- Upgrades `resend` from `6.12.3` to `6.12.4` in `package.json` and `bun.lock`.
- Refreshes the lockfile so Resend's webhook helper dependency now resolves directly to `standardwebhooks` instead of `svix`.
- Checked `.github/workflows/update-umami-tracker.yml`; current action tags are already the latest available tags:
  - `actions/checkout@v6.0.2`
  - `oven-sh/setup-bun@v2.2.0`
  - `peter-evans/create-pull-request@v8.1.1`

## Release-note triage

- Resend `6.12.4`: official release notes list bug fixes, payload mutation fixes, optional constructor configuration additions, React Email template compatibility fixes, and the `svix` to `standardwebhooks` dependency swap.
- This repo uses Resend only in `src/app/api/send-mail/route.tsx` via `new Resend(...)` and `resend.emails.send(...)`; no code/config fallout was required.
- No follow-up issues were created.

## Validation

- `bun run lint` passed.
- `bun run typecheck` passed.
- `bun run format:check` passed.
- `bunx -y react-doctor@latest . --diff main --offline` passed; no changed source files to scan.
- `bun run build` passed.
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-zgceUQ/before` passed before upgrade.
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-zgceUQ/after` passed after upgrade.
- `bun run deps:visual -- compare --before-dir /tmp/uwe-deps-visual-zgceUQ/before --after-dir /tmp/uwe-deps-visual-zgceUQ/after --output-dir /tmp/uwe-deps-visual-zgceUQ/report` passed.

## Visual regression

All seven German targets passed with zero changed pixels:

- `home-hero`
- `home-about`
- `home-experience`
- `home-projects`
- `imprint`
- `privacy`
- `cv`

Artifact root: `/tmp/uwe-deps-visual-zgceUQ`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest patch version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uwe-schwarz/uweschwarz-eu/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->