### PR TITLE
chore(deps): bump postcss to 8.5.15

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "pixelmatch": "^7.2.0",
         "playwright": "^1.60.0",
         "pngjs": "^7.0.0",
-        "postcss": "^8.5.14",
+        "postcss": "^8.5.15",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
       },
@@ -67,7 +67,7 @@
     "sharp",
   ],
   "overrides": {
-    "postcss": "8.5.14",
+    "postcss": "8.5.15",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -800,7 +800,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -854,7 +854,7 @@
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
-    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 

--- a/package.json
+++ b/package.json
@@ -73,12 +73,12 @@
     "pixelmatch": "^7.2.0",
     "playwright": "^1.60.0",
     "pngjs": "^7.0.0",
-    "postcss": "^8.5.14",
+    "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "postcss": "8.5.14"
+    "postcss": "8.5.15"
   },
   "trustedDependencies": [
     "@swc/core",


### PR DESCRIPTION
## Summary
- Upgrade `postcss` from `8.5.14` to `8.5.15` in `package.json` and `bun.lock`.
- Refresh the `postcss` override and lockfile resolution, including transitive `nanoid` `3.3.11` to `3.3.12`.
- Checked `.github/workflows/update-umami-tracker.yml`; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already current.

## Release-note triage
- `postcss` `8.5.15` is a patch update. The npm package metadata shows the only dependency change relevant to this repo is `nanoid` moving to `^3.3.12`; no code/config migration was required.
- No follow-up issues were created.

## Validation
- `bun run lint` - passed
- `bun run typecheck` - passed
- `bun run format:check` - passed
- `bunx -y react-doctor@latest . --diff main --offline` - passed; no changed source files to scan
- `bun run build` - passed
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "$ARTIFACT_ROOT/before"` - passed before upgrade
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir "$ARTIFACT_ROOT/after"` - passed after upgrade
- `bun run deps:visual -- compare --before-dir "$ARTIFACT_ROOT/before" --after-dir "$ARTIFACT_ROOT/after" --output-dir "$ARTIFACT_ROOT/report"` - passed

## Visual regression
- Compared German targets: `/de` hero, about, experience, `#projects`, `/de/imprint`, `/de/privacy`, and `/de/cv`.
- Result: zero changed pixels across all seven targets; no visual drift accepted.
- Local artifact root: `/tmp/uwe-deps-visual-54cmS6`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to the latest patch version to maintain build tool compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uwe-schwarz/uweschwarz-eu/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->