### PR TITLE
chore(deps): upgrade react-hook-form to 7.77.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "next": "^16.2.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-hook-form": "^7.76.1",
+        "react-hook-form": "^7.77.0",
         "react-icons": "^5.6.0",
         "resend": "^6.12.4",
         "sonner": "^2.0.7",
@@ -876,7 +876,7 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
-    "react-hook-form": ["react-hook-form@7.76.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ=="],
+    "react-hook-form": ["react-hook-form@7.77.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg=="],
 
     "react-icons": ["react-icons@5.6.0", "", { "peerDependencies": { "react": "*" } }, "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA=="],
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-hook-form": "^7.76.1",
+    "react-hook-form": "^7.77.0",
     "react-icons": "^5.6.0",
     "resend": "^6.12.4",
     "sonner": "^2.0.7",


### PR DESCRIPTION
## Summary

- Upgrades `react-hook-form` from `7.76.1` to `7.77.0` in `package.json` and `bun.lock`.
- Checked GitHub workflow action tags; `actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already latest.
- Reviewed upstream `react-hook-form` v7.77.0 release notes: new `resetDefaultValues` API, reset/dirty-state fixes, nested field-array error fixes, and prototype-path hardening. No code fallout or deferred follow-up issue needed for this repo's current form usage.

## Validation

- `bun run lint` - passed
- `bun run typecheck` - passed
- `bun run format:check` - passed
- `bunx -y react-doctor@latest . --diff main --offline` - passed; skipped because no source files changed
- `bun run build` - passed
- `node .agents/skills/upgrade-dependencies-pr/scripts/check-no-latest-specifiers.mjs /home/uwe/dev/web/uweschwarz-eu` - passed

## Visual Regression

Artifact root: `/tmp/uwe-deps-visual-Qor4bd`

- Before capture: `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-Qor4bd/before`
- After capture: `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-Qor4bd/after`
- Compare: `bun run deps:visual -- compare --before-dir /tmp/uwe-deps-visual-Qor4bd/before --after-dir /tmp/uwe-deps-visual-Qor4bd/after --output-dir /tmp/uwe-deps-visual-Qor4bd/report`

Result: passed with `changed=0` for all seven German targets (`home-hero`, `home-about`, `home-experience`, `home-projects`, `imprint`, `privacy`, `cv`).

## Follow-ups

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated react-hook-form dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->