### PR TITLE
chore(deps): upgrade @tanstack/react-query to 5.101.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.8",
         "@react-pdf/renderer": "^4.5.1",
-        "@tanstack/react-query": "^5.100.14",
+        "@tanstack/react-query": "^5.101.0",
         "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -490,9 +490,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.0", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "postcss": "^8.5.10", "tailwindcss": "4.3.0" } }, "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.100.14", "", {}, "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.101.0", "", {}, "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.100.14", "", { "dependencies": { "@tanstack/query-core": "5.100.14" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.101.0", "", { "dependencies": { "@tanstack/query-core": "5.101.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.8",
     "@react-pdf/renderer": "^4.5.1",
-    "@tanstack/react-query": "^5.100.14",
+    "@tanstack/react-query": "^5.101.0",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

- Updated `@tanstack/react-query` from `5.100.14` to `5.101.0` in `package.json` and `bun.lock`.
- Updated transitive `@tanstack/query-core` from `5.100.14` to `5.101.0` via the lockfile.
- Checked `.github/workflows/update-umami-tracker.yml`; existing workflow actions are already on current release tags (`actions/checkout@v6.0.2`, `oven-sh/setup-bun@v2.2.0`, `peter-evans/create-pull-request@v8.1.1`).

## Release-note triage

- Official React Query `@tanstack/react-query@5.101.0` release notes list only an updated dependency on `@tanstack/query-core@5.101.0`: https://github.com/TanStack/query/releases/tag/%40tanstack/react-query%405.101.0
- This app only uses React Query for the top-level `QueryClient`/`QueryClientProvider` in `src/app/providers.client.tsx`; no required code changes or follow-up issues were identified.

## Validation

- `bun run lint` passed.
- `bun run typecheck` passed.
- `bun run format:check` passed.
- `bunx -y react-doctor@latest . --diff main --offline` passed. React Doctor reported its config rename notice and skipped because no source files changed.
- `bun run build` passed.
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-8w4XUU/before` completed before the upgrade.
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-8w4XUU/after` completed after the upgrade.
- `bun run deps:visual -- compare --before-dir /tmp/uwe-deps-visual-8w4XUU/before --after-dir /tmp/uwe-deps-visual-8w4XUU/after --output-dir /tmp/uwe-deps-visual-8w4XUU/report` passed with zero changed pixels across all seven German visual targets.

## Visual Regression

- Artifact root: `/tmp/uwe-deps-visual-8w4XUU`
- Result: no visual drift accepted; all targets reported `changed=0`.

## Follow-ups

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest compatible versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->