### PR TITLE
[codex] Upgrade workflow actions

### DIFF
--- a/.github/workflows/update-umami-tracker.yml
+++ b/.github/workflows/update-umami-tracker.yml
@@ -19,10 +19,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -33,7 +35,7 @@ jobs:
         run: bun run update:umami
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           branch: codex/update-umami-tracker
           commit-message: "chore: update vendored Umami tracker"

--- a/.github/workflows/update-umami-tracker.yml
+++ b/.github/workflows/update-umami-tracker.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2.2.0


### PR DESCRIPTION
## Summary
- Upgraded `.github/workflows/update-umami-tracker.yml` from `actions/checkout@v6.0.2` to `actions/checkout@v6.0.3`.
- Pinned all workflow action references to immutable commit SHAs and set `persist-credentials: false` on `actions/checkout` in response to review feedback.
- Ran `bun update --latest` and `bun install`; package dependencies were already at the latest versions resolved by Bun, so `package.json` and `bun.lock` have no package-version changes.
- Verified workflow action tags: `oven-sh/setup-bun@v2.2.0` and `peter-evans/create-pull-request@v8.1.1` were already current.

## Release-note triage
- No package upgrades were introduced, so no package release-note fallout or follow-up issues were needed.
- The changed dependency references are GitHub Actions workflow updates.

## Validation
Initial validation:
- `bun run lint` - passed
- `bun run typecheck` - passed
- `bun run format:check` - passed
- `bunx -y react-doctor@latest . --diff main --offline` - passed; React Doctor noted that `react-doctor.config.json` is deprecated in favor of `doctor.config.*`, and skipped because no source files changed.
- `bun run build` - passed
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-fddruJ/before` - captured 7 baseline targets
- `bun run deps:visual -- capture --base-url http://127.0.0.1:3301 --lang de --output-dir /tmp/uwe-deps-visual-fddruJ/after` - captured 7 after targets
- `bun run deps:visual -- compare --before-dir /tmp/uwe-deps-visual-fddruJ/before --after-dir /tmp/uwe-deps-visual-fddruJ/after --output-dir /tmp/uwe-deps-visual-fddruJ/report` - passed

Follow-up validation after workflow hardening:
- `bun run lint` - passed
- `bun run typecheck` - passed
- `bun run format:check` - passed
- `bunx -y react-doctor@latest . --diff main --offline` - passed with the same config-name notice and no changed source files
- `bun run build` - passed

## Visual Regression
- Result: passed with `changed=0` for all seven German targets: home hero, home about, home experience, home projects, imprint, privacy, and CV.
- No UI files changed after the visual comparison, so the original report remains applicable.
- Artifact root: `/tmp/uwe-deps-visual-fddruJ`

## Follow-up Issues
- None created.
