### PR TITLE
chore(deps): upgrade @types/node to 25.9.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
       "devDependencies": {
         "@nkzw/oxlint-config": "^1.2.1",
         "@tailwindcss/postcss": "^4.3.0",
-        "@types/node": "^25.9.2",
+        "@types/node": "^25.9.3",
         "@types/react": "^19.2.17",
         "@types/three": "^0.184.1",
         "autoprefixer": "^10.5.0",
@@ -632,7 +632,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
@@ -1283,6 +1283,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@types/ws/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@nkzw/oxlint-config": "^1.2.1",
     "@tailwindcss/postcss": "^4.3.0",
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "@types/three": "^0.184.1",
     "autoprefixer": "^10.5.0",


### PR DESCRIPTION
## Summary
- Upgrades `@types/node` from `^25.9.2` to `^25.9.3`.
- Regenerates `bun.lock` with Bun.
- Checked pinned workflow actions in `.github/workflows/update-umami-tracker.yml`; `actions/checkout@v6.0.3`, `oven-sh/setup-bun@v2.2.0`, and `peter-evans/create-pull-request@v8.1.1` are already at their latest releases.

## Release-note triage
- `@types/node` is a patch type-definition update used by Node-based scripts and server/API code. No code or config changes were required.
- No follow-up issues were created.

## Validation
- `bun install`
- `node .agents/skills/upgrade-dependencies-pr/scripts/unpin-semver-ranges.mjs /home/uwe/dev/web/uweschwarz-eu`
- `node .agents/skills/upgrade-dependencies-pr/scripts/check-no-latest-specifiers.mjs /home/uwe/dev/web/uweschwarz-eu`
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bun run doctor`
- `bun run doctor:full`
- `bunx -y react-doctor@latest . --diff main --offline`
- `bun run build`

## Visual regression
- Captured before/after German-language screenshots for `/de` hero, about, experience, projects, `/de/imprint`, `/de/privacy`, and `/de/cv`.
- `bun run deps:visual -- compare --before-dir "$ARTIFACT_ROOT/before" --after-dir "$ARTIFACT_ROOT/after" --output-dir "$ARTIFACT_ROOT/report"`
- Result: PASS with `changed=0` for all 7 targets.
- Artifact root: `/tmp/uwe-deps-visual-3C1FXw`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->